### PR TITLE
Fix build command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,7 @@ The server is designed to be used as an MCP tool provider for MCP Clients. When 
 2. Clone and build the server.
 
     ```sh
-    bun i && bun build
-    ```
+    bun i && bun build ./src/index.ts --outdir ./dist --target node
    
 3. Update your client config (eg: Claude desktop):
 


### PR DESCRIPTION
Fixes build command in README.md

`bun i && bun build` gave me a build failure as you need to specify an entrypoint with bun

Added entry point, output directory and target platform