### PR TITLE
fix: set up server without config errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ npx @pranesh.asp/foundry-mcp-server
 **Claude Code**
 
 ```bash
- claude mcp add-json foundry-mcp-server '{"type":"stdio","command":"npx","args":["@pranesh.asp/foundry-mcp-server"],"env":{"RPC_URL": "", ""PRIVATE_KEY":""}}'   
+ claude mcp add-json foundry-mcp-server '{"type":"stdio","command":"npx","args":["@pranesh.asp/foundry-mcp-server"],"env":{"RPC_URL":"","PRIVATE_KEY":""}}'   
 ```
 
 **Other MCP Clients (Cursor, Claude, Windsurf)**
@@ -150,8 +150,11 @@ The server supports the following environment variables:
 - `PRIVATE_KEY`: Private key to use for transactions (optional)
 
 > [!CAUTION]
-> Do not add keys with mainnet funds. Even though the code uses it safely, LLMs can hallicunate and send malicious transactions. 
+> Do not add keys with mainnet funds. Even though the code uses it safely, LLMs can hallicunate and send malicious transactions.
 > Use it only for testing/development purposes. DO NOT trust the LLM!!
+
+> [!TIP]
+> Getting `Invalid configuration` errors? Check your JSON syntax—common issues include double quotes (`""KEY"` → `"KEY"`), trailing commas, or unquoted keys. Validate with `echo '...' | jq .`
 
 ### Workspace
 


### PR DESCRIPTION
# Summary

Users can now copy the setup command from the README and run it successfully. Previously, a typo in the example caused a confusing "Invalid input" error with no explanation.

# Changes

- Copy and paste the Claude Code setup command without errors
- See a helpful tip explaining common setup mistakes if something goes wrong

Close: https://github.com/PraneshASP/foundry-mcp-server/issues/11